### PR TITLE
Removed `WorkerConnection.FindServiceEntities`

### DIFF
--- a/Improbable/DatabaseSync/Improbable.DatabaseSync.CSharpCodeGen/Improbable.DatabaseSync.CSharpCodeGen.csproj
+++ b/Improbable/DatabaseSync/Improbable.DatabaseSync.CSharpCodeGen/Improbable.DatabaseSync.CSharpCodeGen.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <Version>0.0.1-preview</Version>
-    <Authors>Improbable Worlds, Ltd</Authors>
-    <Copyright>Improbable Worlds, Ltd</Copyright>
     <Description>SpatialOS DatabaseSync Persistence Generator</Description>
   </PropertyGroup>
 

--- a/Improbable/DatabaseSync/Improbable.DatabaseSync/Improbable.DatabaseSync.csproj
+++ b/Improbable/DatabaseSync/Improbable.DatabaseSync/Improbable.DatabaseSync.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 </Project>

--- a/Improbable/Directory.Build.props
+++ b/Improbable/Directory.Build.props
@@ -8,6 +8,5 @@
 
     <Authors>Improbable Worlds, Ltd</Authors>
     <Copyright>Improbable Worlds, Ltd</Copyright>
-    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 </Project>

--- a/Improbable/Improbable.CSharpCodeGen/Improbable.CSharpCodeGen.csproj
+++ b/Improbable/Improbable.CSharpCodeGen/Improbable.CSharpCodeGen.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Improbable/Postgres/Improbable.Postgres.CSharpCodeGen/Improbable.Postgres.CSharpCodeGen.csproj
+++ b/Improbable/Postgres/Improbable.Postgres.CSharpCodeGen/Improbable.Postgres.CSharpCodeGen.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <version>0.0.1-preview</version>
-    <Authors>Improbable Worlds, Ltd</Authors>
-    <Copyright>Improbable Worlds, Ltd</Copyright>
+    <Version>0.0.1-preview</Version>
     <Description>SpatialOS Postgres Code Generator</Description>
   </PropertyGroup>
 

--- a/Improbable/Postgres/Improbable.Postgres/Improbable.Postgres.csproj
+++ b/Improbable/Postgres/Improbable.Postgres/Improbable.Postgres.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>x64</Platforms>
+    <Version>0.0.2-preview</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.5.0" />

--- a/Improbable/Postgres/Improbable.Postgres/MetricsPusher.cs
+++ b/Improbable/Postgres/Improbable.Postgres/MetricsPusher.cs
@@ -65,7 +65,7 @@ namespace Improbable.Postgres
         {
             metricsCancellationTokenSource = new CancellationTokenSource();
 
-            metricsPusherTask = Task.Run(() => Run(interval, metricsCancellationTokenSource.Token));
+            metricsPusherTask = Task.Run(() => Run(interval, metricsCancellationTokenSource.Token), metricsCancellationTokenSource.Token);
         }
 
         private async Task Run(TimeSpan interval, CancellationToken cancellationToken)

--- a/Improbable/Postgres/Improbable.Postgres/MetricsPusher.cs
+++ b/Improbable/Postgres/Improbable.Postgres/MetricsPusher.cs
@@ -9,7 +9,7 @@ namespace Improbable.Postgres
 {
     public class MetricsPusher : IDisposable
     {
-        private readonly CancellationTokenSource metricsCancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource metricsCancellationTokenSource;
         private readonly PostgresOptions postgresOptions;
         private Task metricsPusherTask;
 
@@ -20,9 +20,16 @@ namespace Improbable.Postgres
 
         public void Dispose()
         {
-            StopPushingMetrics();
+            metricsCancellationTokenSource?.Cancel();
+            metricsPusherTask?.Wait();
+
             metricsCancellationTokenSource?.Dispose();
             metricsPusherTask?.Dispose();
+
+            metricsCancellationTokenSource = null;
+            metricsPusherTask = null;
+
+            GC.SuppressFinalize(this);
         }
 
         private void Scrape()
@@ -56,15 +63,10 @@ namespace Improbable.Postgres
 
         public void StartPushingMetrics(TimeSpan interval)
         {
+            metricsCancellationTokenSource = new CancellationTokenSource();
+
             metricsPusherTask = Task.Run(() => Run(interval, metricsCancellationTokenSource.Token));
         }
-
-        public void StopPushingMetrics()
-        {
-            metricsCancellationTokenSource?.Cancel();
-            metricsPusherTask?.Wait();
-        }
-
 
         private async Task Run(TimeSpan interval, CancellationToken cancellationToken)
         {

--- a/Improbable/Schema/Improbable.Schema.Bundle/Improbable.Schema.Bundle.csproj
+++ b/Improbable/Schema/Improbable.Schema.Bundle/Improbable.Schema.Bundle.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>latest</LangVersion>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Improbable/Stdlib/Improbable.Stdlib.CSharpCodeGen/Improbable.Stdlib.CSharpCodeGen.csproj
+++ b/Improbable/Stdlib/Improbable.Stdlib.CSharpCodeGen/Improbable.Stdlib.CSharpCodeGen.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Improbable/Stdlib/Improbable.Stdlib/Improbable.Stdlib.csproj
+++ b/Improbable/Stdlib/Improbable.Stdlib/Improbable.Stdlib.csproj
@@ -5,6 +5,7 @@
     <Platforms>x64</Platforms>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Version>0.0.2-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Improbable/Stdlib/Improbable.Stdlib/WorkerConnection.cs
+++ b/Improbable/Stdlib/Improbable.Stdlib/WorkerConnection.cs
@@ -545,27 +545,6 @@ namespace Improbable.Stdlib
             }
         }
 
-        public IEnumerable<KeyValuePair<EntityId, Entity>> FindServiceEntities(uint componentId)
-        {
-            return FindServiceEntities(componentId, CancellationToken.None);
-        }
-
-        public IEnumerable<KeyValuePair<EntityId, Entity>> FindServiceEntities(uint componentId, CancellationToken token)
-        {
-            var serviceQuery = SendEntityQueryRequest(new EntityQuery {Constraint = new ComponentConstraint(componentId), ResultType = new SnapshotResultType()});
-            foreach (var opList in GetOpLists(TimeSpan.FromMilliseconds(16), token))
-            {
-                ProcessOpList(opList);
-
-                if (serviceQuery.IsCompleted)
-                {
-                    break;
-                }
-            }
-
-            return serviceQuery.Result.Results;
-        }
-
         private static async Task<double> GetCpuUsageForProcess(CancellationToken cancellationToken)
         {
             var startTime = DateTime.UtcNow;

--- a/Improbable/Test/Improbable.Test/Improbable.Test.csproj
+++ b/Improbable/Test/Improbable.Test/Improbable.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>x64</Platforms>
 
+    <Version>0.0.1-preview</Version>
     <Description>SpatialOS Test Helpers</Description>
   </PropertyGroup>
 

--- a/Improbable/WorkerSdkInterop/Improbable.WorkerSdkInterop.CSharpCodegen/Improbable.WorkerSdkInterop.CSharpCodeGen.csproj
+++ b/Improbable/WorkerSdkInterop/Improbable.WorkerSdkInterop.CSharpCodegen/Improbable.WorkerSdkInterop.CSharpCodeGen.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The simple implementation of this could cause other parts of the worker to miss important ops.
Instead, structure user code to explicitly query for the desired service entity
Deferring creation uncovered a bug in `PostgresOptions`:
* Fixed `PostgresOptions` to be thread-safe, and to validate its inputs
Simplfiied `MetricsScraper` as a drive-by, since investigation of the above moved through this code