### PR TITLE
Refactored ops processing so that they are deserialized in a backgrou...

### DIFF
--- a/Improbable/Stdlib/Improbable.Stdlib/Ops.cs
+++ b/Improbable/Stdlib/Improbable.Stdlib/Ops.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Stdlib
@@ -10,6 +11,8 @@ namespace Improbable.Stdlib
         public readonly List<Op> Ops;
 
         private readonly Worker.CInterop.OpList rawOps;
+
+        public static OpList Empty = new OpList();
 
         public OpList()
         {
@@ -86,7 +89,7 @@ namespace Improbable.Stdlib
 
         public void Dispose()
         {
-            rawOps.Dispose();
+            rawOps?.Dispose();
         }
 
         public IEnumerator<Op> GetEnumerator()
@@ -99,6 +102,7 @@ namespace Improbable.Stdlib
             return GetEnumerator();
         }
 
+        [DebuggerDisplay("{"+ nameof(Worker.CInterop.OpType) + "}")]
         public struct Op
         {
             public OpType OpType;

--- a/Improbable/Stdlib/Improbable.Stdlib/Ops.cs
+++ b/Improbable/Stdlib/Improbable.Stdlib/Ops.cs
@@ -102,7 +102,7 @@ namespace Improbable.Stdlib
             return GetEnumerator();
         }
 
-        [DebuggerDisplay("{"+ nameof(Worker.CInterop.OpType) + "}")]
+        [DebuggerDisplay("{" + nameof(OpType) + "}")]
         public struct Op
         {
             public OpType OpType;

--- a/Improbable/Stdlib/Improbable.Stdlib/WorkerConnection.cs
+++ b/Improbable/Stdlib/Improbable.Stdlib/WorkerConnection.cs
@@ -25,6 +25,8 @@ namespace Improbable.Stdlib
         private readonly BlockingCollection<OpList> ops = new BlockingCollection<OpList>();
         private Task processOpsTask;
 
+        public string WorkerId { get; }
+
         private WorkerConnection(Connection connection)
         {
             this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -70,8 +72,6 @@ namespace Improbable.Stdlib
                 }
             }, TaskCreationOptions.LongRunning);
         }
-
-        public string WorkerId { get; }
 
         public void Dispose()
         {
@@ -620,7 +620,7 @@ namespace Improbable.Stdlib
         {
             var startTime = DateTime.UtcNow;
             var startCpuUsage = Process.GetCurrentProcess().TotalProcessorTime;
-            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken).ConfigureAwait(false);
 
             var endTime = DateTime.UtcNow;
             var endCpuUsage = Process.GetCurrentProcess().TotalProcessorTime;

--- a/Workers/GameLogic/Program.cs
+++ b/Workers/GameLogic/Program.cs
@@ -86,14 +86,13 @@ namespace GameLogic
                 DefaultComponentVtable = new ComponentVtable()
             };
 
-            using (var asyncConnection = await WorkerConnection.ConnectAsync(options, connectionParameters))
+            using (var connection = await WorkerConnection.ConnectAsync(options, connectionParameters).ConfigureAwait(false))
             {
-                asyncConnection.StartSendingMetrics();
+                connection.StartSendingMetrics();
 
-                foreach (var opList in asyncConnection.GetOpLists(TimeSpan.FromMilliseconds(0)))
+                foreach (var opList in connection.GetOpLists())
                 {
                     ProcessOpList(opList);
-                    asyncConnection.ProcessOpList(opList);
                 }
             }
 


### PR DESCRIPTION
…nd task

Command results are now delivered from this background task
This makes it easier for users to avoid deadlocking themselves while bootstrapping their workers
e.g. Sending an Entity query to find service entities before starting the main loop